### PR TITLE
Fix: rel path in process_dir and process_file 

### DIFF
--- a/R/process-dir.R
+++ b/R/process-dir.R
@@ -212,6 +212,7 @@ process_dir <- function(
   stopifnot(is.null(output_dir) || fs::dir_exists(output_dir))
   stopifnot(is.null(layout_filepath) || fs::file_exists(layout_filepath))
   stopifnot(is_mba_format(format, allow_nullable = TRUE))
+  input_dir <- fs::path_abs(input_dir)
 
   input_files <- c()
   for (input_file in fs::dir_ls(input_dir, recurse = recurse)) {

--- a/R/process-file.R
+++ b/R/process-file.R
@@ -50,6 +50,7 @@ process_file <- function(
     stop("Plate filepath is required.")
   }
   stopifnot(fs::file_exists(plate_filepath))
+  plate_filepath <- fs::path_abs(plate_filepath)
 
   plate <- read_luminex_data(plate_filepath, layout_filepath, format = format)
 

--- a/tests/testthat/test-process-dir.R
+++ b/tests/testthat/test-process-dir.R
@@ -77,9 +77,13 @@ test_that("Test processing a mock directory", {
   expect_no_error(capture.output(
     process_dir(dir, dry_run = T, recurse = T, flatten_output_dir = F, output_dir = tempdir(check = TRUE))
   ))
+  # Test with relative path
+  rel_path <- fs::path_rel(dir, getwd())
+  expect_no_error(capture.output(
+    process_dir(rel_path, dry_run = T, recurse = T, flatten_output_dir = F, output_dir = tempdir(check = TRUE))
+  ))
 
   dir <- tempdir(check = TRUE)
-
   # Clean up the tmp directory
   unlink(dir, recursive = T)
   dir.create(dir)


### PR DESCRIPTION
Directly related to issue #251

Solved by casting path to absolute path at the start of both functions 