### PR TITLE
feat: Separate MFI outputs

### DIFF
--- a/R/config.R
+++ b/R/config.R
@@ -13,7 +13,7 @@ SerolyzeR.env$mba_pattern <- paste(
 )
 
 # Normalisation types
-SerolyzeR.env$normalisation_types <- c("RAU", "nMFI")
+SerolyzeR.env$normalisation_types <- c("MFI", "RAU", "nMFI")
 
 # String patterns for declared normalisation types
 SerolyzeR.env$normalisation_pattern <- paste0(

--- a/R/process-dir.R
+++ b/R/process-dir.R
@@ -200,7 +200,7 @@ process_dir <- function(
     flatten_output_dir = FALSE,
     layout_filepath = NULL,
     format = NULL,
-    normalisation_types = c("RAU", "nMFI"),
+    normalisation_types = c("MFI", "RAU", "nMFI"),
     generate_reports = FALSE,
     merge_outputs = FALSE,
     column_collision_strategy = "intersection",
@@ -308,7 +308,7 @@ process_dir <- function(
       for (plate in plates) {
         output_df <- process_plate(plate,
           normalisation_type = normalisation_type, write_output = FALSE,
-          include_raw_mfi = TRUE, adjust_blanks = TRUE, verbose = verbose
+          adjust_blanks = TRUE, verbose = verbose
         )
         df_header_columns <- data.frame(
           plate_name = plate$plate_name,

--- a/R/process-dir.R
+++ b/R/process-dir.R
@@ -308,7 +308,7 @@ process_dir <- function(
       for (plate in plates) {
         output_df <- process_plate(plate,
           normalisation_type = normalisation_type, write_output = FALSE,
-          adjust_blanks = TRUE, verbose = verbose
+          blank_adjustment = TRUE, verbose = verbose
         )
         df_header_columns <- data.frame(
           plate_name = plate$plate_name,

--- a/R/process-dir.R
+++ b/R/process-dir.R
@@ -163,7 +163,7 @@ get_output_dir <- function(
 #' be determined automatically based on the file name. Available options are `xPONENT` and `INTELLIFLEX`.
 #' @param layout_filepath (`character(1)`) The path to the layout file. The default is `NULL`, and the layout file will have to
 #' be determined automatically based on the file name.
-#' @param normalisation_types (`character()`) A vector of normalisation types to use. The default is `c("RAU", "nMFI")`.
+#' @param normalisation_types (`character()`) A vector of normalisation types to use. The default is `c("MFI", "RAU", "nMFI")`.
 #' @param generate_reports (`logical(1)`) If `TRUE`, generate quality control reports for each file. The default is `FALSE`.
 #' @param merge_outputs (`logical(1)`) If `TRUE`, merge the outputs of all plates into a single CSV file for each normalisation type.
 #' The resulting file will be saved in the output directory with the name `merged_{normalisation_type}_{timestamp}.csv`.

--- a/R/process-file.R
+++ b/R/process-file.R
@@ -17,7 +17,7 @@
 #' @param process_plate (`logical(1)`) If `TRUE`, process the plate. The default is `TRUE`.
 #' If the value is set to `FALSE` the function will only read the plate file and return the plate object.
 #' @param normalisation_types (`character()`) A vector of normalisation types to use. The default is `c("MFI", "RAU", "nMFI")`.
-#' @param adjust_blanks (`logical(1)`) If `TRUE`, adjust the blank values. The default is `FALSE`.#'
+#' @param blank_adjustment (`logical(1)`) If `TRUE`, adjust the blank values. The default is `FALSE`.#'
 #' @param verbose (`logical(1)`) Print additional information. The default is `TRUE`.
 #' @param ... Additional arguments to for the `read_luminex_data` function.
 #'
@@ -46,7 +46,7 @@ process_file <- function(
     generate_report = FALSE,
     process_plate = TRUE,
     normalisation_types = c("MFI", "RAU", "nMFI"),
-    adjust_blanks = FALSE,
+    blank_adjustment = FALSE,
     verbose = TRUE,
     ...) {
   if (is.null(plate_filepath)) {
@@ -63,7 +63,7 @@ process_file <- function(
       process_plate(
         plate,
         normalisation_type = normalisation_type, output_dir = output_dir,
-        adjust_blanks = adjust_blanks, verbose = verbose
+        blank_adjustment = blank_adjustment, verbose = verbose
       )
     }
   }

--- a/R/process-file.R
+++ b/R/process-file.R
@@ -17,7 +17,6 @@
 #' @param process_plate (`logical(1)`) If `TRUE`, process the plate. The default is `TRUE`.
 #' If the value is set to `FALSE` the function will only read the plate file and return the plate object.
 #' @param normalisation_types (`character()`) A vector of normalisation types to use. The default is `c("RAU", "nMFI")`.
-#' @param include_raw_mfi (`logical(1)`) If `TRUE`, include the raw MFI values in the normalised data. The default is `TRUE`.
 #' @param adjust_blanks (`logical(1)`) If `TRUE`, adjust the blank values. The default is `FALSE`.#'
 #' @param verbose (`logical(1)`) Print additional information. The default is `TRUE`.
 #' @param ... Additional arguments to for the `read_luminex_data` function.
@@ -45,8 +44,7 @@ process_file <- function(
     format = "xPONENT",
     generate_report = FALSE,
     process_plate = TRUE,
-    normalisation_types = c("RAU", "nMFI"),
-    include_raw_mfi = TRUE,
+    normalisation_types = c("MFI", "RAU", "nMFI"),
     adjust_blanks = FALSE,
     verbose = TRUE,
     ...) {
@@ -64,7 +62,7 @@ process_file <- function(
       process_plate(
         plate,
         normalisation_type = normalisation_type, output_dir = output_dir,
-        include_raw_mfi = include_raw_mfi, adjust_blanks = adjust_blanks, verbose = verbose
+        adjust_blanks = adjust_blanks, verbose = verbose
       )
     }
   }

--- a/R/process-file.R
+++ b/R/process-file.R
@@ -16,7 +16,7 @@
 #' @param generate_report (`logical(1)`) If `TRUE`, generate a quality control report. The default is `FALSE`.
 #' @param process_plate (`logical(1)`) If `TRUE`, process the plate. The default is `TRUE`.
 #' If the value is set to `FALSE` the function will only read the plate file and return the plate object.
-#' @param normalisation_types (`character()`) A vector of normalisation types to use. The default is `c("RAU", "nMFI")`.
+#' @param normalisation_types (`character()`) A vector of normalisation types to use. The default is `c("MFI", "RAU", "nMFI")`.
 #' @param adjust_blanks (`logical(1)`) If `TRUE`, adjust the blank values. The default is `FALSE`.#'
 #' @param verbose (`logical(1)`) Print additional information. The default is `TRUE`.
 #' @param ... Additional arguments to for the `read_luminex_data` function.
@@ -29,6 +29,7 @@
 #'
 #' example_dir <- tempdir(check = TRUE) # a temporary directory
 #' # create and save dataframe with computed dilutions for all suported noramlization types
+#' # that inclused the raw MFI values as well
 #' process_file(plate_file, layout_file, output_dir = example_dir)
 #'
 #' example_dir2 <- tempdir(check = TRUE) # a temporary directory

--- a/R/process-plate.R
+++ b/R/process-plate.R
@@ -7,11 +7,11 @@ is_valid_normalisation_type <- function(normalisation_type) {
 #'
 #' @description
 #' Depending on the `normalisation_type` argument, the function will compute the RAU or nMFI values for each analyte in the plate.
+#' Additionally the `normalisation_type` can be set to `MFI` resulting in a dataframe of the raw (blank adjusted) MFI values.
 #' **RAU** is the default normalisation type.
 #'
-#'
 #' The behaviour of the function, in the case of RAU normalisation type, can be summarised as follows:
-#' 1. Adjust blanks if not already done.
+#' 1. Adjust blanks if `adjust_blanks` is set to `TRUE`.
 #' 2. Fit a model to each analyte using standard curve samples.
 #' 3. Compute RAU values for each analyte using the corresponding model.
 #' 4. Aggregate computed RAU values into a single data frame.
@@ -21,14 +21,23 @@ is_valid_normalisation_type <- function(normalisation_type) {
 #' `create_standard_curve_model_analyte` function documentation \link[SerolyzeR]{create_standard_curve_model_analyte} or in the Model reference \link[SerolyzeR]{Model}.
 #'
 #'
-#'
-#' In case the normalisation type is **nMFI**, the function will:
-#' 1. Adjust blanks if not already done.
+#' In case the normalisation type being **nMFI**, the function will:
+#' 1. Adjust blanks if `adjust_blanks` is set to `TRUE`.
 #' 2. Compute nMFI values for each analyte using the target dilution.
 #' 3. Aggregate computed nMFI values into a single data frame.
 #' 4. Save the computed nMFI values to a CSV file.
 #'
 #' More info about the nMFI normalisation can be found in `get_nmfi` function documentation \link[SerolyzeR]{get_nmfi}.
+#'
+#'
+#' In case of normalisation type "MFI", the function will:
+#' 1. Adjust blanks if `adjust_blanks` is set to `TRUE`.
+#' 2. Save the blank adjusted MFI values to a CSV file.
+#'
+#'
+#' If the plate is already blank adjusted when calling the method,
+#' the parameter `adjust_blanks` has not effect.
+#'
 #'
 #' @param plate (`Plate()`) a plate object
 #' @param filename (`character(1)`) The name of the output CSV file with normalised MFI values.

--- a/R/process-plate.R
+++ b/R/process-plate.R
@@ -11,7 +11,7 @@ is_valid_normalisation_type <- function(normalisation_type) {
 #' **RAU** is the default normalisation type.
 #'
 #' The behaviour of the function, in the case of RAU normalisation type, can be summarised as follows:
-#' 1. Adjust blanks if `adjust_blanks` is set to `TRUE`.
+#' 1. Blank adjust the plate if `blank_adjustment` is set to `TRUE`.
 #' 2. Fit a model to each analyte using standard curve samples.
 #' 3. Compute RAU values for each analyte using the corresponding model.
 #' 4. Aggregate computed RAU values into a single data frame.
@@ -22,7 +22,7 @@ is_valid_normalisation_type <- function(normalisation_type) {
 #'
 #'
 #' In case the normalisation type being **nMFI**, the function will:
-#' 1. Adjust blanks if `adjust_blanks` is set to `TRUE`.
+#' 1. Blank adjust the plate if `blank_adjustment` is set to `TRUE`.
 #' 2. Compute nMFI values for each analyte using the target dilution.
 #' 3. Aggregate computed nMFI values into a single data frame.
 #' 4. Save the computed nMFI values to a CSV file.
@@ -31,12 +31,12 @@ is_valid_normalisation_type <- function(normalisation_type) {
 #'
 #'
 #' In case of normalisation type "MFI", the function will:
-#' 1. Adjust blanks if `adjust_blanks` is set to `TRUE`.
+#' 1. Blank adjust the plate if `blank_adjustment` is set to `TRUE`.
 #' 2. Save the blank adjusted MFI values to a CSV file.
 #'
 #'
 #' If the plate is already blank adjusted when calling the method,
-#' the parameter `adjust_blanks` has not effect.
+#' the parameter `blank_adjustment` has no effect.
 #'
 #'
 #' @param plate (`Plate()`) a plate object
@@ -61,7 +61,7 @@ is_valid_normalisation_type <- function(normalisation_type) {
 #' @param normalisation_type (`character(1)`) type of normalisation to use. Available options are:
 #' \cr \code{c(`r toString(SerolyzeR.env$normalisation_types)`)}.
 #' @param data_type (`character(1)`) type of data to use for the computation. Median is the default
-#' @param adjust_blanks (`logical(1)`) adjust blanks before computing RAU values. The default is `FALSE`
+#' @param blank_adjustment (`logical(1)`) perform blank adjustment on the plate before computing normalised values. The default is `FALSE`
 #' @param verbose (`logical(1)`) print additional information. The default is `TRUE`
 #' @param reference_dilution (`numeric(1)`) target dilution to use as reference for the nMFI normalisation. Ignored in case of RAU normalisation.
 #' Default is `1/400`.
@@ -82,10 +82,10 @@ is_valid_normalisation_type <- function(normalisation_type) {
 #' # create and save dataframe with computed dilutions
 #' process_plate(plate, output_dir = example_dir)
 #'
-#' # process plate without adjusting blanks and save the output to a file with a custom name
+#' # process plate without blank adjustment and save the output to a file with a custom name
 #' process_plate(plate,
-#'   filename = "plate_without_blanks_adjusted.csv",
-#'   output_dir = example_dir, adjust_blanks = FALSE
+#'   filename = "plate_no_blank_adjustment.csv",
+#'   output_dir = example_dir, blank_adjustment = FALSE
 #' )
 #'
 #'
@@ -104,7 +104,7 @@ process_plate <-
            write_output = TRUE,
            normalisation_type = "RAU",
            data_type = "Median",
-           adjust_blanks = FALSE,
+           blank_adjustment = FALSE,
            verbose = TRUE,
            reference_dilution = 1 / 400,
            ...) {
@@ -124,7 +124,7 @@ process_plate <-
     }
 
 
-    if (!plate$blank_adjusted && adjust_blanks) {
+    if ((!plate$blank_adjusted) && blank_adjustment) {
       plate <- plate$blank_adjustment(in_place = FALSE)
     }
 

--- a/man/process_dir.Rd
+++ b/man/process_dir.Rd
@@ -11,7 +11,7 @@ process_dir(
   flatten_output_dir = FALSE,
   layout_filepath = NULL,
   format = NULL,
-  normalisation_types = c("RAU", "nMFI"),
+  normalisation_types = c("MFI", "RAU", "nMFI"),
   generate_reports = FALSE,
   merge_outputs = FALSE,
   column_collision_strategy = "intersection",

--- a/man/process_dir.Rd
+++ b/man/process_dir.Rd
@@ -37,7 +37,7 @@ be determined automatically based on the file name.}
 \item{format}{(\code{character(1)}) The format of the Luminex data. The default is \code{NULL}, and the format will have to
 be determined automatically based on the file name. Available options are \code{xPONENT} and \code{INTELLIFLEX}.}
 
-\item{normalisation_types}{(\code{character()}) A vector of normalisation types to use. The default is \code{c("RAU", "nMFI")}.}
+\item{normalisation_types}{(\code{character()}) A vector of normalisation types to use. The default is \code{c("MFI", "RAU", "nMFI")}.}
 
 \item{generate_reports}{(\code{logical(1)}) If \code{TRUE}, generate quality control reports for each file. The default is \code{FALSE}.}
 

--- a/man/process_file.Rd
+++ b/man/process_file.Rd
@@ -31,7 +31,7 @@ process_file(
 \item{process_plate}{(\code{logical(1)}) If \code{TRUE}, process the plate. The default is \code{TRUE}.
 If the value is set to \code{FALSE} the function will only read the plate file and return the plate object.}
 
-\item{normalisation_types}{(\code{character()}) A vector of normalisation types to use. The default is \code{c("RAU", "nMFI")}.}
+\item{normalisation_types}{(\code{character()}) A vector of normalisation types to use. The default is \code{c("MFI", "RAU", "nMFI")}.}
 
 \item{adjust_blanks}{(\code{logical(1)}) If \code{TRUE}, adjust the blank values. The default is \code{FALSE}.#'}
 
@@ -54,6 +54,7 @@ layout_file <- system.file("extdata", "CovidOISExPONTENT_CO_layout.xlsx", packag
 
 example_dir <- tempdir(check = TRUE) # a temporary directory
 # create and save dataframe with computed dilutions for all suported noramlization types
+# that inclused the raw MFI values as well
 process_file(plate_file, layout_file, output_dir = example_dir)
 
 example_dir2 <- tempdir(check = TRUE) # a temporary directory

--- a/man/process_file.Rd
+++ b/man/process_file.Rd
@@ -11,8 +11,7 @@ process_file(
   format = "xPONENT",
   generate_report = FALSE,
   process_plate = TRUE,
-  normalisation_types = c("RAU", "nMFI"),
-  include_raw_mfi = TRUE,
+  normalisation_types = c("MFI", "RAU", "nMFI"),
   adjust_blanks = FALSE,
   verbose = TRUE,
   ...
@@ -33,8 +32,6 @@ process_file(
 If the value is set to \code{FALSE} the function will only read the plate file and return the plate object.}
 
 \item{normalisation_types}{(\code{character()}) A vector of normalisation types to use. The default is \code{c("RAU", "nMFI")}.}
-
-\item{include_raw_mfi}{(\code{logical(1)}) If \code{TRUE}, include the raw MFI values in the normalised data. The default is \code{TRUE}.}
 
 \item{adjust_blanks}{(\code{logical(1)}) If \code{TRUE}, adjust the blank values. The default is \code{FALSE}.#'}
 

--- a/man/process_file.Rd
+++ b/man/process_file.Rd
@@ -12,7 +12,7 @@ process_file(
   generate_report = FALSE,
   process_plate = TRUE,
   normalisation_types = c("MFI", "RAU", "nMFI"),
-  adjust_blanks = FALSE,
+  blank_adjustment = FALSE,
   verbose = TRUE,
   ...
 )
@@ -33,7 +33,7 @@ If the value is set to \code{FALSE} the function will only read the plate file a
 
 \item{normalisation_types}{(\code{character()}) A vector of normalisation types to use. The default is \code{c("MFI", "RAU", "nMFI")}.}
 
-\item{adjust_blanks}{(\code{logical(1)}) If \code{TRUE}, adjust the blank values. The default is \code{FALSE}.#'}
+\item{blank_adjustment}{(\code{logical(1)}) If \code{TRUE}, adjust the blank values. The default is \code{FALSE}.#'}
 
 \item{verbose}{(\code{logical(1)}) Print additional information. The default is \code{TRUE}.}
 

--- a/man/process_plate.Rd
+++ b/man/process_plate.Rd
@@ -11,7 +11,7 @@ process_plate(
   write_output = TRUE,
   normalisation_type = "RAU",
   data_type = "Median",
-  adjust_blanks = FALSE,
+  blank_adjustment = FALSE,
   verbose = TRUE,
   reference_dilution = 1/400,
   ...
@@ -43,7 +43,7 @@ specified by \code{filename} parameter. The default is \code{TRUE}.}
 
 \item{data_type}{(\code{character(1)}) type of data to use for the computation. Median is the default}
 
-\item{adjust_blanks}{(\code{logical(1)}) adjust blanks before computing RAU values. The default is \code{FALSE}}
+\item{blank_adjustment}{(\code{logical(1)}) perform blank adjustment on the plate before computing normalised values. The default is \code{FALSE}}
 
 \item{verbose}{(\code{logical(1)}) print additional information. The default is \code{TRUE}}
 
@@ -65,7 +65,7 @@ Additionally the \code{normalisation_type} can be set to \code{MFI} resulting in
 
 The behaviour of the function, in the case of RAU normalisation type, can be summarised as follows:
 \enumerate{
-\item Adjust blanks if \code{adjust_blanks} is set to \code{TRUE}.
+\item Blank adjust the plate if \code{blank_adjustment} is set to \code{TRUE}.
 \item Fit a model to each analyte using standard curve samples.
 \item Compute RAU values for each analyte using the corresponding model.
 \item Aggregate computed RAU values into a single data frame.
@@ -77,7 +77,7 @@ More info about the RAU normalisation can be found in
 
 In case the normalisation type being \strong{nMFI}, the function will:
 \enumerate{
-\item Adjust blanks if \code{adjust_blanks} is set to \code{TRUE}.
+\item Blank adjust the plate if \code{blank_adjustment} is set to \code{TRUE}.
 \item Compute nMFI values for each analyte using the target dilution.
 \item Aggregate computed nMFI values into a single data frame.
 \item Save the computed nMFI values to a CSV file.
@@ -87,12 +87,12 @@ More info about the nMFI normalisation can be found in \code{get_nmfi} function 
 
 In case of normalisation type "MFI", the function will:
 \enumerate{
-\item Adjust blanks if \code{adjust_blanks} is set to \code{TRUE}.
+\item Blank adjust the plate if \code{blank_adjustment} is set to \code{TRUE}.
 \item Save the blank adjusted MFI values to a CSV file.
 }
 
 If the plate is already blank adjusted when calling the method,
-the parameter \code{adjust_blanks} has not effect.
+the parameter \code{blank_adjustment} has no effect.
 }
 \examples{
 
@@ -106,10 +106,10 @@ example_dir <- tempdir(check = TRUE) # a temporary directory
 # create and save dataframe with computed dilutions
 process_plate(plate, output_dir = example_dir)
 
-# process plate without adjusting blanks and save the output to a file with a custom name
+# process plate without blank adjustment and save the output to a file with a custom name
 process_plate(plate,
-  filename = "plate_without_blanks_adjusted.csv",
-  output_dir = example_dir, adjust_blanks = FALSE
+  filename = "plate_no_blank_adjustment.csv",
+  output_dir = example_dir, blank_adjustment = FALSE
 )
 
 

--- a/man/process_plate.Rd
+++ b/man/process_plate.Rd
@@ -60,11 +60,12 @@ a data frame with normalised values
 }
 \description{
 Depending on the \code{normalisation_type} argument, the function will compute the RAU or nMFI values for each analyte in the plate.
+Additionally the \code{normalisation_type} can be set to \code{MFI} resulting in a dataframe of the raw (blank adjusted) MFI values.
 \strong{RAU} is the default normalisation type.
 
 The behaviour of the function, in the case of RAU normalisation type, can be summarised as follows:
 \enumerate{
-\item Adjust blanks if not already done.
+\item Adjust blanks if \code{adjust_blanks} is set to \code{TRUE}.
 \item Fit a model to each analyte using standard curve samples.
 \item Compute RAU values for each analyte using the corresponding model.
 \item Aggregate computed RAU values into a single data frame.
@@ -74,15 +75,24 @@ The behaviour of the function, in the case of RAU normalisation type, can be sum
 More info about the RAU normalisation can be found in
 \code{create_standard_curve_model_analyte} function documentation \link[SerolyzeR]{create_standard_curve_model_analyte} or in the Model reference \link[SerolyzeR]{Model}.
 
-In case the normalisation type is \strong{nMFI}, the function will:
+In case the normalisation type being \strong{nMFI}, the function will:
 \enumerate{
-\item Adjust blanks if not already done.
+\item Adjust blanks if \code{adjust_blanks} is set to \code{TRUE}.
 \item Compute nMFI values for each analyte using the target dilution.
 \item Aggregate computed nMFI values into a single data frame.
 \item Save the computed nMFI values to a CSV file.
 }
 
 More info about the nMFI normalisation can be found in \code{get_nmfi} function documentation \link[SerolyzeR]{get_nmfi}.
+
+In case of normalisation type "MFI", the function will:
+\enumerate{
+\item Adjust blanks if \code{adjust_blanks} is set to \code{TRUE}.
+\item Save the blank adjusted MFI values to a CSV file.
+}
+
+If the plate is already blank adjusted when calling the method,
+the parameter \code{adjust_blanks} has not effect.
 }
 \examples{
 

--- a/man/process_plate.Rd
+++ b/man/process_plate.Rd
@@ -11,7 +11,6 @@ process_plate(
   write_output = TRUE,
   normalisation_type = "RAU",
   data_type = "Median",
-  include_raw_mfi = TRUE,
   adjust_blanks = FALSE,
   verbose = TRUE,
   reference_dilution = 1/400,
@@ -40,13 +39,9 @@ If it equals to \code{NULL} the current working directory will be used. Default 
 specified by \code{filename} parameter. The default is \code{TRUE}.}
 
 \item{normalisation_type}{(\code{character(1)}) type of normalisation to use. Available options are:
-\cr \code{c(RAU, nMFI)}.}
+\cr \code{c(MFI, RAU, nMFI)}.}
 
 \item{data_type}{(\code{character(1)}) type of data to use for the computation. Median is the default}
-
-\item{include_raw_mfi}{(\code{logical(1)}) include raw MFI values in the output. The default is \code{TRUE}.
-In case this option is \code{TRUE}, the output dataframe contains two columns for each analyte: one for the normalised values and one for the raw MFI values.
-The normalised columns are named as \code{AnalyteName} and \code{AnalyteName_raw}, respectively.}
 
 \item{adjust_blanks}{(\code{logical(1)}) adjust blanks before computing RAU values. The default is \code{FALSE}}
 

--- a/tests/testthat/test-process-plate.R
+++ b/tests/testthat/test-process-plate.R
@@ -20,6 +20,11 @@ test_that("Test processing of a plate", {
     process_plate(plate, output_dir = tmp_dir, filename = "output.csv")
   )
 
+  # Test outputing MFI vaules to CSV file through the process_plate function
+  expect_no_error(
+    process_plate(plate, output_dir = tmp_dir, filename = "output.csv", normalisation_type = "MFI")
+  )
+
 
   # Test additional parameters
   expect_error(
@@ -69,7 +74,7 @@ test_that("Processing plate with nMFI", {
 })
 
 
-test_that("raw MFI in dataframe", {
+test_that("Test rows and columns in the output dataframes", {
   # Read plate
   path <- system.file("extdata", "CovidOISExPONTENT.csv", package = "SerolyzeR", mustWork = TRUE)
   layout_path <- system.file("extdata", "CovidOISExPONTENT_layout.xlsx", package = "SerolyzeR", mustWork = TRUE)
@@ -79,17 +84,11 @@ test_that("raw MFI in dataframe", {
   tmp_dir <- tempdir(check = TRUE)
   test_output_path <- file.path(tmp_dir, "output.csv")
   expect_no_error(
-    output_df <- process_plate(plate, output_dir = tmp_dir, filename = "output.csv", normalisation_type = "nMFI", include_raw_mfi = FALSE)
+    output_df <- process_plate(plate, output_dir = tmp_dir, filename = "output.csv", normalisation_type = "nMFI")
   )
   stopifnot(all(colnames(output_df) == plate$analyte_names))
+  stopifnot(all(rownames(output_df) == plate$sample_names[plate$sample_types == "TEST"]))
 
   file.remove(test_output_path)
-
-  # Test processing of a plate, with raw MFI
-  expect_no_error(
-    output_df <- process_plate(plate, output_dir = tmp_dir, filename = "output.csv", normalisation_type = "nMFI", include_raw_mfi = TRUE)
-  )
-  stopifnot(all(colnames(output_df) == c(plate$analyte_names, paste0(plate$analyte_names, "_raw"))))
-
   unlink(tmp_dir, recursive = TRUE)
 })


### PR DESCRIPTION
1. Remove `raw_`  columns from the output files for normalisations (RAU, nMFI). Remove `include_raw_mfi` parameter from methods
2. Allow setting `MFI` as the normalisation type for process_plate, file, dir
3. Update the documentation for each function
4. Rename `adjust_blanks` argument to `blank_adjustment` as the blanks are not adjusted in the process but rather blanks are used in the process of blank adjustment the plate 

Related to the #259 