### PR TITLE
feat: change the default datetime format

### DIFF
--- a/R/parser.R
+++ b/R/parser.R
@@ -62,8 +62,8 @@ parse_xponent_locations <- function(xponent_locations) {
 handle_datetime <- function(datetime_str, file_format = "xPONENT") {
   if (file_format == "xPONENT") {
     possible_orders <- c(
-      "mdY IM p", "mdY HM", "mdY IMS p", "mdY HMS",
-      "Ymd IM p", "Ymd HM", "Ymd IMS p", "Ymd HMS",
+      "Ymd HM", "mdY IM p", "mdY HM", "mdY IMS p", 
+      "mdY HMS", "Ymd IM p", "Ymd IMS p", "Ymd HMS",
       "dmY IM p", "dmY HM", "dmY IMS p", "dmY HMS"
     )
   } else if (file_format == "INTELLIFLEX") {


### PR DESCRIPTION
Reading all the files from Paris, we recieved the warning:

![image](https://github.com/user-attachments/assets/1db3f4fc-37c0-4a49-8016-ea1a9b388d8e)

now, we got rid of this warning