### PR TITLE
fix: reduce time of example execution

### DIFF
--- a/R/merge-plate-outputs.R
+++ b/R/merge-plate-outputs.R
@@ -36,6 +36,7 @@ merge_plate_outputs <- function(
     column_collision_strategy = "intersection",
     verbose = TRUE,
     ...) {
+    
   if (!is.character(normalisation_type) || length(normalisation_type) != 1) {
     stop("`normalisation_type` must be a single character string.")
   }

--- a/R/merge-plate-outputs.R
+++ b/R/merge-plate-outputs.R
@@ -27,9 +27,6 @@
 #'   return_plates = TRUE, format = "xPONENT", output_dir = output_dir
 #' )
 #'
-#' df <- merge_plate_outputs(list_of_plates, "RAU")
-#'
-#'
 #' df <- merge_plate_outputs(list_of_plates, "RAU", sample_type_filter = c("TEST", "STANDARD CURVE"))
 #'
 #' @export

--- a/man/merge_plate_outputs.Rd
+++ b/man/merge_plate_outputs.Rd
@@ -46,9 +46,6 @@ list_of_plates <- process_dir(dir_with_luminex_files,
   return_plates = TRUE, format = "xPONENT", output_dir = output_dir
 )
 
-df <- merge_plate_outputs(list_of_plates, "RAU")
-
-
 df <- merge_plate_outputs(list_of_plates, "RAU", sample_type_filter = c("TEST", "STANDARD CURVE"))
 
 }


### PR DESCRIPTION
It was noted in the following CRAN check:
https://win-builder.r-project.org/incoming_pretest/SerolyzeR_1.3.0_20250717_184240/Debian/00check.log